### PR TITLE
🎨 Palette: Show detailed error messages for failed images

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,5 @@
+## 2026-05-12 - Added error output for failed images
+
+**Learning:** Users need to know exactly which images failed during batch processing. An overall error message is not
+actionable. **Action:** Always output detailed errors for individual batch items when a batch process fails, even if it
+adds to terminal noise, because the user needs to correct specific items.

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,9 +104,12 @@ if (result.some(pr => pr.status === 'rejected')) {
     )
 
     for (const pr of result) {
-        if (pr.status === 'rejected') {
-            log.error(pr.reason instanceof Error ? pr.reason.message : String(pr.reason))
+        if (pr.status === 'fulfilled') {
+            continue
         }
+
+        const message = getMessage(pr.reason)
+        log.error(message)
     }
 
     outroMessage = 'please check your input files and try again 🛠️'

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,6 +69,13 @@ if (result.some(pr => pr.status === 'rejected')) {
     spin.error(
         `yikes! finished with errors. processed ${color.red(processed)}/${color.red(images.length)} images in ${color.yellow(duration)} seconds 😢`
     )
+
+    for (const pr of result) {
+        if (pr.status === 'rejected') {
+            log.error(pr.reason instanceof Error ? pr.reason.message : String(pr.reason))
+        }
+    }
+
     outroMessage = 'please check your input files and try again 🛠️'
 } else {
     spin.stop(`yay! ${color.green(images.length)} images processed in ${color.green(duration)} seconds! ⚡`)


### PR DESCRIPTION
💡 What: Updated the error handling in `src/index.ts` to output detailed error messages for individual images that fail processing.
🎯 Why: Previously, when an image failed to process, `lumi` would only show a generic "yikes! finished with errors" message, leaving users guessing which specific image(s) caused the problem. This change improves the developer/user experience by explicitly printing the underlying error (e.g. unsupported format) so they can take actionable steps.
📸 Before/After: Not a visual UI change, but improves CLI output readability.
♿ Accessibility: N/A

---
*PR created automatically by Jules for task [15234026195263533391](https://jules.google.com/task/15234026195263533391) started by @nathievzm*