### PR TITLE
⚡ Bolt: optimize array allocations and cache sharp formats

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -6,3 +6,6 @@
 - **Action:** When iterating over potentially large lists (like file paths), favor a single-pass `for...of` loop over
   chained array methods to minimize memory footprint. Always pull static Set creation outside of function scopes to
   initialize them once at the module level.
+## 2024-05-14 - [Static Caching in Modules]
+**Learning:** Functions repeatedly evaluating static property arrays (like `Object.values(sharp.format)`) incur high performance overhead per-call. Chained methods like `.filter().map()` compound this by allocating multiple temporary arrays.
+**Action:** Lift purely static computations out of function scopes (or lazily cache them at the module level). Use a single-pass `for...of` loop over large property arrays when constructing lists of options.

--- a/src/lib/image.ts
+++ b/src/lib/image.ts
@@ -51,21 +51,39 @@ const isFormatInfo = (value: unknown): value is AvailableFormatInfo =>
     typeof value === 'object' && value !== null && 'output' in value && 'id' in value
 
 /**
+ * ⚡ Bolt: Cache sharp formats at the module level to avoid recalculating them on each call.
+ * This also replaces multiple array allocations (.filter().filter().map()) with a single pass.
+ */
+let cachedSharpFormats: Option<string>[] | undefined = undefined
+
+/**
  * Retrieves the list of image formats supported by Sharp for output.
  *
  * @returns An array of options representing the supported formats.
  */
 const getSharpFormats = () => {
-    const sharpFormats = Object.values(sharp.format).filter(format => isFormatInfo(format))
-    const formats: Option<string>[] = sharpFormats
-        .filter(format => format.output.file)
-        .map(format => ({ label: format.id, value: `.${format.id}` }))
+    if (cachedSharpFormats) {
+        return cachedSharpFormats
+    }
 
+    const formats: Option<string>[] = []
+    for (const format of Object.values(sharp.format)) {
+        if (isFormatInfo(format) && format.output.file) {
+            formats.push({ label: format.id, value: `.${format.id}` })
+        }
+    }
+
+    cachedSharpFormats = formats
     return formats
 }
 
-const inputFormats = imageExtensions.map(format => `.${format}`)
-const validExtensions = new Set(inputFormats)
+/**
+ * ⚡ Bolt: Avoid intermediate array allocations by directly adding items to the Set.
+ */
+const validExtensions = new Set<string>()
+for (const format of imageExtensions) {
+    validExtensions.add(`.${format}`)
+}
 
 /**
  * Filters a list of files to return only those with supported image extensions.
@@ -75,10 +93,17 @@ const validExtensions = new Set(inputFormats)
  * @returns An array of file paths that are recognized as images.
  */
 export const getImages = (files: readonly string[]) => {
-    const images = files.filter(file => {
+    /**
+     * ⚡ Bolt: Use a single-pass for...of loop instead of .filter() to reduce intermediate
+     * array allocations and callback overhead when handling a large number of files.
+     */
+    const images: string[] = []
+    for (const file of files) {
         const ext = extname(file)
-        return validExtensions.has(ext.toLowerCase())
-    })
+        if (validExtensions.has(ext.toLowerCase())) {
+            images.push(file)
+        }
+    }
 
     return images
 }


### PR DESCRIPTION
💡 **What:** 
- Lazily cached the sharp format options at the module level.
- Replaced chained `.filter().map()` calls with single-pass `for...of` loops in `getSharpFormats`.
- Directly populated the `validExtensions` Set using a `for...of` loop instead of chained map/array structures.
- Reduced intermediate array allocations in `getImages` by using a single-pass loop with `.push()` instead of `.filter()`.

🎯 **Why:** 
When processing directories with a large number of files, reducing memory allocations (garbage collection pressure) and function call overhead significantly speeds up the operation. Rebuilding the supported formats list inside `getSharpFormats()` repeatedly was unnecessary since `sharp.format` is static.

📊 **Impact:** 
- Reduces memory allocations during image filtering.
- Avoids redundant static evaluation of format capabilities.
- Execution speed scales more gracefully with large input directories.

🔬 **Measurement:** 
Run `bun run lint` and verify processing of large directories works consistently with reduced CPU profiling overhead inside array methods.

---
*PR created automatically by Jules for task [5639896709952352292](https://jules.google.com/task/5639896709952352292) started by @nathievzm*