### PR TITLE
🎨 Palette: Add default initialValue for format prompt

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,16 +1,16 @@
-## 2026-05-13 - Friendly CLI Errors
-
-- **Learning:** Raw stack traces from unhandled Promise rejections (like `readdir` on a non-existent directory) are
-  intimidating for CLI users.
-- **Action:** Always wrap file I/O operations in `try...catch` blocks and use UI logging tools (like `@clack/prompts`)
-  to provide actionable, human-readable error messages before gracefully exiting.
-
 ## 2026-05-12 - Added error output for failed images
 
 - **Learning:** Users need to know exactly which images failed during batch processing. An overall error message is not
   actionable.
 - **Action:** Always output detailed errors for individual batch items when a batch process fails, even if it adds to
   terminal noise, because the user needs to correct specific items.
+
+## 2026-05-13 - Friendly CLI Errors
+
+- **Learning:** Raw stack traces from unhandled Promise rejections (like `readdir` on a non-existent directory) are
+  intimidating for CLI users.
+- **Action:** Always wrap file I/O operations in `try...catch` blocks and use UI logging tools (like `@clack/prompts`)
+  to provide actionable, human-readable error messages before gracefully exiting.
 
 ## 2026-05-14 - Default CLI Prompt Values
 

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -11,3 +11,10 @@
   actionable.
 - **Action:** Always output detailed errors for individual batch items when a batch process fails, even if it adds to
   terminal noise, because the user needs to correct specific items.
+
+## 2026-05-14 - Default CLI Prompt Values
+
+- **Learning:** When prompting users for repeated or common file conversions, failing to default to the original format
+  creates unnecessary friction. Users expect smart defaults that save keystrokes.
+- **Action:** Always set an `initialValue` in CLI selection prompts (`@clack/prompts`) where a logical default exists,
+  such as defaulting to a file's original extension during conversion options.

--- a/src/lib/prompt.ts
+++ b/src/lib/prompt.ts
@@ -112,6 +112,7 @@ export const askExtensions = (extensions: readonly string[], formats: readonly R
 
         promptGroups[extension] = () => {
             const initialValue = formats.some(format => format.value === extension) ? extension : undefined
+
             return select({
                 initialValue,
                 message: `what ${color.magenta('format')} do you want to use for ${color.cyan(extension)} files? 🎨`,

--- a/src/lib/prompt.ts
+++ b/src/lib/prompt.ts
@@ -104,11 +104,14 @@ export const askExtensions = (extensions: readonly string[], formats: readonly R
             continue
         }
 
-        promptGroups[extension] = () =>
-            select({
+        promptGroups[extension] = () => {
+            const initialValue = formats.some(format => format.value === extension) ? extension : undefined
+            return select({
+                initialValue,
                 message: `what ${color.magenta('format')} do you want to use for ${color.cyan(extension)} files? 🎨`,
                 options: [...formats]
             })
+        }
     }
 
     return group(promptGroups, {


### PR DESCRIPTION
💡 **What:** Added an `initialValue` option to the format selection prompt in the CLI. The prompt now defaults to the file's original extension if it's included in the list of available formats.

🎯 **Why:** Users shouldn't have to manually select the default option for every file type. Providing a smart default makes batch conversions less tedious, saving them keystrokes and preventing unnecessary scrolling.

♿ **Accessibility/UX:** Improves general CLI usability. Reduces cognitive load for the user when making quick selections.

*Added learning to journal about smart defaults in CLI choices.*

---
*PR created automatically by Jules for task [12642777553951717797](https://jules.google.com/task/12642777553951717797) started by @nathievzm*