### PR TITLE
🎨 Palette: Enhance text input UX with default dimension

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -18,3 +18,8 @@
   creates unnecessary friction. Users expect smart defaults that save keystrokes.
 - **Action:** Always set an `initialValue` in CLI selection prompts (`@clack/prompts`) where a logical default exists,
   such as defaulting to a file's original extension during conversion options.
+
+## 2026-05-16 - Text Input Prompts Default Values
+
+- **Learning:** Text input prompts for users to provide numerical dimensions is repetitive and adds friction, especially when standard sizes are desired.
+- **Action:** Added `defaultValue` and `initialValue` to text prompts asking for dimensions to reduce keystrokes and friction for typical use-cases.

--- a/src/lib/prompt.ts
+++ b/src/lib/prompt.ts
@@ -59,6 +59,8 @@ export const askWidthAndHeight = async () => {
     const regex = /\d+/gv
 
     const result = await text({
+        defaultValue: '1080',
+        initialValue: '1080',
         message: `what ${color.magenta('dimensions')} do you want for the ${color.magenta('output')} images? 📐`,
         placeholder: 'e.g. "1080" (square) or "1920 1080" (width x height)',
         validate: value => {


### PR DESCRIPTION
💡 **What:** Added `defaultValue` and `initialValue` ('1080') to the `@clack/prompts` dimension prompt.
🎯 **Why:** To reduce user friction by providing a sensible default for users who frequently use this tool for standard square sizes. Users can just hit enter.
📸 **Before/After:** Not applicable (terminal change).
♿ **Accessibility:** It speeds up keyboard-only navigation.

---
*PR created automatically by Jules for task [1880240556123643877](https://jules.google.com/task/1880240556123643877) started by @nathievzm*