### PR TITLE
🎨 Palette: Add `initialValue` to dimensions prompt

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -18,3 +18,7 @@
   creates unnecessary friction. Users expect smart defaults that save keystrokes.
 - **Action:** Always set an `initialValue` in CLI selection prompts (`@clack/prompts`) where a logical default exists,
   such as defaulting to a file's original extension during conversion options.
+## 2024-05-17 - Add initialValue to dimensions prompt
+
+- **Learning:** Found a micro-UX pattern of providing sensible defaults (`initialValue`) in @clack/prompts text inputs. This improves usability by reducing repetitive typing for common values (like 1080px).
+- **Action:** Added `initialValue: '1080'` to the dimensions prompt in `src/lib/prompt.ts`. Will continue looking for similar opportunities to reduce friction in CLI tools by leveraging `defaultValue` or `initialValue` options.

--- a/src/lib/prompt.ts
+++ b/src/lib/prompt.ts
@@ -59,6 +59,7 @@ export const askWidthAndHeight = async () => {
     const regex = /\d+/gv
 
     const result = await text({
+        initialValue: '1080',
         message: `what ${color.magenta('dimensions')} do you want for the ${color.magenta('output')} images? 📐`,
         placeholder: 'e.g. "1080" (square) or "1920 1080" (width x height)',
         validate: value => {


### PR DESCRIPTION
💡 **What:** Added `initialValue: '1080'` to the dimensions prompt in `askWidthAndHeight`.
🎯 **Why:** To provide a sensible default for users and reduce repetitive typing for common sizes.
♿ **Accessibility:** This decreases the interaction cost of the CLI tool.

---
*PR created automatically by Jules for task [8363643186920383457](https://jules.google.com/task/8363643186920383457) started by @nathievzm*