### PR TITLE
🎨 Palette: Add default value to dimensions prompt

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -18,3 +18,6 @@
   creates unnecessary friction. Users expect smart defaults that save keystrokes.
 - **Action:** Always set an `initialValue` in CLI selection prompts (`@clack/prompts`) where a logical default exists,
   such as defaulting to a file's original extension during conversion options.
+## 2024-05-19 - Default Values in Prompts Reduce Friction
+**Learning:** Setting default values (`defaultValue`, `initialValue`) in interactive CLI prompts greatly improves the user experience by providing a logical starting point and reducing cognitive load or necessary keystrokes.
+**Action:** Always provide a logical default value in `@clack/prompts` and similar interactive interfaces when a common or safe default exists.

--- a/src/lib/prompt.ts
+++ b/src/lib/prompt.ts
@@ -59,6 +59,8 @@ export const askWidthAndHeight = async () => {
     const regex = /\d+/gv
 
     const result = await text({
+        defaultValue: '1080',
+        initialValue: '1080',
         message: `what ${color.magenta('dimensions')} do you want for the ${color.magenta('output')} images? 📐`,
         placeholder: 'e.g. "1080" (square) or "1920 1080" (width x height)',
         validate: value => {


### PR DESCRIPTION
💡 What: Added `defaultValue: '1080'` and `initialValue: '1080'` to the dimensions `text` prompt in `src/lib/prompt.ts`.
🎯 Why: Providing a logical default value for common user inputs (like 1080 for image processing) reduces friction, cognitive load, and saves keystrokes.
📸 Before/After: The prompt now starts with `1080` prefilled, whereas before it started empty.
♿ Accessibility: Reduces the amount of typing required for users, and gives an immediate working example of expected input format.

---
*PR created automatically by Jules for task [4584495545442890100](https://jules.google.com/task/4584495545442890100) started by @nathievzm*