### PR TITLE
🛡️ Sentinel: [MEDIUM] Add null byte checks to CLI inputs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -57,3 +57,11 @@ boundary check, not just the immediately obvious file path.
 
 **Prevention:** Ensure comprehensive null byte validation (`\0`) on all path inputs (both base directories and target
 paths) prior to resolving them with `node:path` functions.
+
+## 2024-05-22 - [Add null byte checks to CLI inputs]
+
+**Vulnerability:** Path Traversal via Null Byte Injection in CLI Input (`getInput` / `getOutput`). **Learning:**
+Although `guard` protected output resolution, raw input/output strings derived from the CLI or env could contain
+injected null bytes (`\0`) early in the pipeline. This could be used to truncate resolved paths and bypass security
+mechanisms later in execution. **Prevention:** Explicitly validate all user-supplied paths early in the function logic
+(`getInput`, `getOutput`) and reject strings containing null characters (`\0`) to prevent evasion techniques.

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@nathievzm/lumi",

--- a/src/lib/folder.ts
+++ b/src/lib/folder.ts
@@ -19,6 +19,10 @@ import { FolderError } from './error'
  */
 export const getInput = (input?: string) => {
     if (input !== undefined && input !== '') {
+        if (input.includes('\0')) {
+            throw new FolderError('path traversal detected 🚫')
+        }
+
         log.info(`input folder provided: ${color.cyan(input)} 📂`)
         return input
     }
@@ -41,6 +45,10 @@ export const getInput = (input?: string) => {
  */
 export const getOutput = (output?: string) => {
     if (output !== undefined && output !== '') {
+        if (output.includes('\0')) {
+            throw new FolderError('path traversal detected 🚫')
+        }
+
         log.info(`output folder provided: ${color.cyan(output)} 📂`)
         return output
     }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Raw input and output paths taken from the CLI could contain null bytes, which could lead to path traversal/truncation bugs down the line by bypassing `guard`.
🎯 Impact: An attacker could potentially read or write files outside the expected directories if they can supply a null byte to bypass string-based bound checks.
🔧 Fix: Add explicit `\0` checks in `getInput` and `getOutput` to throw a `FolderError` early.
✅ Verification: Ran `bun run lint` and `bun run fmt:check`. Verified code passes manually and via automated review.

---
*PR created automatically by Jules for task [13779054632896753686](https://jules.google.com/task/13779054632896753686) started by @nathievzm*