### PR TITLE
🎨 Palette: Improve 'no valid images' error message with actionable hint

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -38,3 +38,11 @@ legitimately need a wide variety of formats (like dimensions).
 
 **Action:** Avoid using `initialValue` or `defaultValue` in free-text inputs like dimensions, where a helpful
 placeholder explaining multiple formats is more valuable.
+
+## 2026-05-22 - Helpful Error Messages
+
+**Learning:** When a batch process fails to find images because they are nested in subdirectories, an overall error
+message is not actionable enough. Users often forget to use the `--recursive` flag.
+
+**Action:** Always provide actionable hints in error messages when user intent is clear but they might have missed a
+flag.

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,8 @@ try {
     const images = getImages(allFiles)
 
     if (images.length === 0) {
-        throw new ImageError('no valid images found in the input folder 😭')
+        const hint = cli.recursive ? '' : '\n💡 tip: try using the --recursive (-r) flag if they are in subfolders'
+        throw new ImageError(`no valid images found in the input folder 😭${hint}`)
     }
 
     note(`found ${color.magenta(images.length)} images to process! 🚀`)


### PR DESCRIPTION
Adds a micro-UX improvement by providing an actionable hint to the 'no valid images found' error message, suggesting the use of the `--recursive` flag. Also logs this learning in the palette journal.

---
*PR created automatically by Jules for task [3681734201449317186](https://jules.google.com/task/3681734201449317186) started by @nathievzm*