### PR TITLE
🎨 Palette: Add actionable hint for empty state when no images found

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -48,3 +48,11 @@ them needing to clear the field first.
 
 **Action:** Avoid setting an `initialValue` in CLI text prompts when a descriptive `placeholder` is present, to ensure
 the helpful placeholder text remains visible to the user.
+
+## 2026-05-23 - Empty State Actionable Hints
+
+**Learning:** When users encounter an empty state (like no images found in a directory), they might not realize the tool
+can search subdirectories if told to do so. A generic "not found" error doesn't help them discover available features.
+
+**Action:** Always provide actionable hints in empty states or error messages (e.g., suggesting the `--recursive` flag)
+to guide the user toward a solution and improve feature discoverability.

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,9 @@ try {
     const images = getImages(allFiles)
 
     if (images.length === 0) {
+        if (!cli.recursive) {
+            note('hint: try adding the --recursive flag if your images are in subdirectories 📁', '💡 tip')
+        }
         throw new ImageError('no valid images found in the input folder 😭')
     }
 


### PR DESCRIPTION
💡 What: Added an actionable hint when the tool fails to find images in the input directory.
🎯 Why: To guide users to discover the `--recursive` flag, as they might have images in subdirectories and be unaware of how to process them.
📸 Before/After: Before, just an error message. After, an additional helpful tip suggests `hint: try adding the --recursive flag if your images are in subdirectories 📁`.
♿ Accessibility: Improves cognitive accessibility and error recovery by offering a clear next step instead of just a dead end.

---
*PR created automatically by Jules for task [5609948988424784094](https://jules.google.com/task/5609948988424784094) started by @nathievzm*