### PR TITLE
⚡ Bolt: Cache sharp dynamic import promise in concurrent loops

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -42,3 +42,12 @@ startup time of the CLI, making `lumi --help` and error reporting feel slow.
 
 **Action:** Used dynamic imports (`await import('sharp')`) to lazily load the library only when image processing methods
 (`resize` and `getSharpFormats`) are called. This avoids importing `sharp` during the synchronous CLI startup path.
+
+## 2026-05-23 - [Cache dynamic imports in concurrent tasks]
+
+**Learning:** When dynamically importing heavy modules (like 'sharp') for concurrent processing (e.g., inside 'p-limit'
+loops), caching the import promise avoids the overhead of resolving the dynamic import repeatedly across concurrent
+threads.
+
+**Action:** Use a module-level variable to cache the promise returned by the dynamic import when it will be called
+multiple times in concurrent loops.

--- a/src/lib/image.ts
+++ b/src/lib/image.ts
@@ -2,6 +2,8 @@ import { extname, join } from 'node:path'
 
 import { type Option } from '@clack/prompts'
 import imageExtensions from 'image-extensions'
+import type sharp from 'sharp'
+// eslint-disable-next-line no-duplicate-imports
 import { type AvailableFormatInfo } from 'sharp'
 
 import { ImageError } from './error'
@@ -55,14 +57,23 @@ const validExtensions = new Set(inputFormats)
 const isFormatInfo = (value: unknown): value is AvailableFormatInfo =>
     typeof value === 'object' && value !== null && 'output' in value && 'id' in value
 
+// eslint-disable-next-line init-declarations
+let sharpPromise: Promise<{ default: typeof sharp }> | undefined
+
+const getSharp = () => {
+    // eslint-disable-next-line no-unsafe-type-assertion
+    sharpPromise ??= import('sharp') as unknown as Promise<{ default: typeof sharp }>
+    return sharpPromise
+}
+
 /**
  * Retrieves a list of image formats supported by the Sharp library for output processing.
  *
  * @returns An array of prompt-compatible `Option` objects representing the supported output formats.
  */
 const getSharpFormats = async () => {
-    const { default: sharp } = await import('sharp')
-    const sharpFormats = Object.values(sharp.format).filter(format => isFormatInfo(format))
+    const { default: sharpLib } = await getSharp()
+    const sharpFormats = Object.values(sharpLib.format).filter(format => isFormatInfo(format))
 
     const formats: Option<string>[] = sharpFormats
         .filter(format => format.output.file)
@@ -167,9 +178,9 @@ export const resize = async (params: ResizeParams) => {
         guard(input, inputPath)
         guard(output, outputPath)
 
-        const { default: sharp } = await import('sharp')
+        const { default: sharpLib } = await getSharp()
 
-        await sharp(inputPath, { animated: true })
+        await sharpLib(inputPath, { animated: true })
             .resize(width, height, { background: 'transparent', fit: 'contain' })
             .toFile(outputPath)
 


### PR DESCRIPTION
💡 **What:** Caches the `sharp` dynamic import promise in a module-level variable (`sharpPromise`).
🎯 **Why:** In high-concurrency tasks (like those spawned by `p-limit`), repeatedly calling `import('sharp')` incurs an overhead as the module resolution is hit multiple times. Caching the promise ensures the dynamic import is only initiated and resolved once.
📊 **Impact:** Reduces redundant module resolution overhead in concurrent contexts.
🔬 **Measurement:** Running the CLI on a large folder of images will show slightly improved processing times and reduced Node event loop overhead for module resolution.

Project: lumi
Milestone: v1.2.0 - 💜 jules' magic touch 🐙

---
*PR created automatically by Jules for task [13802778833818989838](https://jules.google.com/task/13802778833818989838) started by @nathievzm*