### PR TITLE
🎨 Palette: Provide actionable hint when no images are found

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -48,3 +48,11 @@ them needing to clear the field first.
 
 **Action:** Avoid setting an `initialValue` in CLI text prompts when a descriptive `placeholder` is present, to ensure
 the helpful placeholder text remains visible to the user.
+
+## 2026-05-24 - Actionable Error Hints
+
+**Learning:** Users who encounter 'no items found' errors during batch processes might not realize there are flags (like
+--recursive) that could find nested items.
+
+**Action:** Always provide actionable hints in error messages or empty states (e.g., suggesting the --recursive flag) to
+guide the user toward a solution.

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,8 @@ try {
     const images = getImages(allFiles)
 
     if (images.length === 0) {
-        throw new ImageError('no valid images found in the input folder 😭')
+        const hint = cli.recursive ? '' : '\n💡 hint: try using the --recursive flag if they are in subfolders'
+        throw new ImageError(`no valid images found in the input folder 😭${hint}`)
     }
 
     note(`found ${color.magenta(images.length)} images to process! 🚀`)


### PR DESCRIPTION
🎨 Palette: Actionable error hints when no images are found

💡 What: Modified the `ImageError` thrown when no valid images are found to dynamically include a hint suggesting the `--recursive` flag if it was omitted.
🎯 Why: Empty states should be helpful. This guides the user to use the correct tool flag instead of just hitting a dead end if their files are in subdirectories.
♿ Accessibility / UX: Improves usability by converting a generic error into an actionable suggestion.
📝 Journaled the UX learning in `.jules/palette.md`.

---
*PR created automatically by Jules for task [474046719175525102](https://jules.google.com/task/474046719175525102) started by @nathievzm*