### PR TITLE
⚡ Bolt: cache sharp dynamic import

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -42,3 +42,7 @@ startup time of the CLI, making `lumi --help` and error reporting feel slow.
 
 **Action:** Used dynamic imports (`await import('sharp')`) to lazily load the library only when image processing methods
 (`resize` and `getSharpFormats`) are called. This avoids importing `sharp` during the synchronous CLI startup path.
+## 2024-05-18 - Avoid typeof on imported default types
+**Learning:** When asserting a type on a dynamically imported module by extracting its default export (e.g. `typeof sharp`), the `typeof` keyword must not be applied if the module has been imported specifically into the type space via `import { type default as sharp } from 'sharp'`. Applying `typeof` to a type-only import results in a `TS2693` compilation error because `typeof` operates on values, not types.
+
+**Action:** When strictly importing types to satisfy `import(consistent-type-specifier-style)`, directly apply the imported type without `typeof`.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -42,7 +42,13 @@ startup time of the CLI, making `lumi --help` and error reporting feel slow.
 
 **Action:** Used dynamic imports (`await import('sharp')`) to lazily load the library only when image processing methods
 (`resize` and `getSharpFormats`) are called. This avoids importing `sharp` during the synchronous CLI startup path.
-## 2024-05-18 - Avoid typeof on imported default types
-**Learning:** When asserting a type on a dynamically imported module by extracting its default export (e.g. `typeof sharp`), the `typeof` keyword must not be applied if the module has been imported specifically into the type space via `import { type default as sharp } from 'sharp'`. Applying `typeof` to a type-only import results in a `TS2693` compilation error because `typeof` operates on values, not types.
 
-**Action:** When strictly importing types to satisfy `import(consistent-type-specifier-style)`, directly apply the imported type without `typeof`.
+## 2024-05-18 - Avoid typeof on imported default types
+
+**Learning:** When asserting a type on a dynamically imported module by extracting its default export (e.g.
+`typeof sharp`), the `typeof` keyword must not be applied if the module has been imported specifically into the type
+space via `import { type default as sharp } from 'sharp'`. Applying `typeof` to a type-only import results in a `TS2693`
+compilation error because `typeof` operates on values, not types.
+
+**Action:** When strictly importing types to satisfy `import(consistent-type-specifier-style)`, directly apply the
+imported type without `typeof`.

--- a/src/lib/image.ts
+++ b/src/lib/image.ts
@@ -2,7 +2,7 @@ import { extname, join } from 'node:path'
 
 import { type Option } from '@clack/prompts'
 import imageExtensions from 'image-extensions'
-import { type AvailableFormatInfo } from 'sharp'
+import { type AvailableFormatInfo, type default as sharp } from 'sharp'
 
 import { ImageError } from './error'
 import { guard } from './folder'
@@ -46,6 +46,25 @@ const inputFormats = imageExtensions.map(format => `.${format}`)
 const validExtensions = new Set(inputFormats)
 
 /**
+ * ⚡ Bolt: Cache the heavy dynamic import of sharp to avoid resolving it repeatedly
+ * in concurrent threads (e.g. inside the p-limit loop during batch resize).
+ */
+// eslint-disable-next-line init-declarations
+let sharpPromise: Promise<{ default: typeof sharp }> | undefined
+
+/**
+ * Helper to get the cached sharp module promise.
+ *
+ * @returns A promise resolving to the default export of the sharp module.
+ */
+const getSharp = async () => {
+    // eslint-disable-next-line no-unsafe-type-assertion
+    sharpPromise ??= import('sharp') as unknown as Promise<{ default: typeof sharp }>
+    const { default: sModule } = await sharpPromise
+    return sModule
+}
+
+/**
  * A type guard to verify if an unknown value conforms to the `AvailableFormatInfo` structure from Sharp.
  *
  * @param value - The unknown value to evaluate.
@@ -61,8 +80,8 @@ const isFormatInfo = (value: unknown): value is AvailableFormatInfo =>
  * @returns An array of prompt-compatible `Option` objects representing the supported output formats.
  */
 const getSharpFormats = async () => {
-    const { default: sharp } = await import('sharp')
-    const sharpFormats = Object.values(sharp.format).filter(format => isFormatInfo(format))
+    const sharpModule = await getSharp()
+    const sharpFormats = Object.values(sharpModule.format).filter(format => isFormatInfo(format))
 
     const formats: Option<string>[] = sharpFormats
         .filter(format => format.output.file)
@@ -167,9 +186,9 @@ export const resize = async (params: ResizeParams) => {
         guard(input, inputPath)
         guard(output, outputPath)
 
-        const { default: sharp } = await import('sharp')
+        const sharpModule = await getSharp()
 
-        await sharp(inputPath, { animated: true })
+        await sharpModule(inputPath, { animated: true })
             .resize(width, height, { background: 'transparent', fit: 'contain' })
             .toFile(outputPath)
 

--- a/src/lib/image.ts
+++ b/src/lib/image.ts
@@ -2,7 +2,7 @@ import { extname, join } from 'node:path'
 
 import { type Option } from '@clack/prompts'
 import imageExtensions from 'image-extensions'
-import { type AvailableFormatInfo, type default as sharp } from 'sharp'
+import { type AvailableFormatInfo, type default as sharpType } from 'sharp'
 
 import { ImageError } from './error'
 import { guard } from './folder'
@@ -45,12 +45,7 @@ interface ResizeParams {
 const inputFormats = imageExtensions.map(format => `.${format}`)
 const validExtensions = new Set(inputFormats)
 
-/**
- * ⚡ Bolt: Cache the heavy dynamic import of sharp to avoid resolving it repeatedly
- * in concurrent threads (e.g. inside the p-limit loop during batch resize).
- */
-// eslint-disable-next-line init-declarations
-let sharpPromise: Promise<{ default: typeof sharp }> | undefined
+let sharpPromise: Promise<{ default: typeof sharpType }> | undefined = undefined
 
 /**
  * Helper to get the cached sharp module promise.
@@ -58,10 +53,9 @@ let sharpPromise: Promise<{ default: typeof sharp }> | undefined
  * @returns A promise resolving to the default export of the sharp module.
  */
 const getSharp = async () => {
-    // eslint-disable-next-line no-unsafe-type-assertion
-    sharpPromise ??= import('sharp') as unknown as Promise<{ default: typeof sharp }>
-    const { default: sModule } = await sharpPromise
-    return sModule
+    sharpPromise ??= import('sharp')
+    const { default: sharp } = await sharpPromise
+    return sharp
 }
 
 /**
@@ -80,8 +74,8 @@ const isFormatInfo = (value: unknown): value is AvailableFormatInfo =>
  * @returns An array of prompt-compatible `Option` objects representing the supported output formats.
  */
 const getSharpFormats = async () => {
-    const sharpModule = await getSharp()
-    const sharpFormats = Object.values(sharpModule.format).filter(format => isFormatInfo(format))
+    const sharp = await getSharp()
+    const sharpFormats = Object.values(sharp.format).filter(format => isFormatInfo(format))
 
     const formats: Option<string>[] = sharpFormats
         .filter(format => format.output.file)
@@ -186,9 +180,9 @@ export const resize = async (params: ResizeParams) => {
         guard(input, inputPath)
         guard(output, outputPath)
 
-        const sharpModule = await getSharp()
+        const sharp = await getSharp()
 
-        await sharpModule(inputPath, { animated: true })
+        await sharp(inputPath, { animated: true })
             .resize(width, height, { background: 'transparent', fit: 'contain' })
             .toFile(outputPath)
 


### PR DESCRIPTION
💡 **What:** Caches the promise of the dynamic import of `sharp` at the module level in `src/lib/image.ts`.
🎯 **Why:** Dynamically importing a heavy module like `sharp` inside concurrent threads (`p-limit` loop in `index.ts`) incurs unnecessary repeated module resolution overhead. Caching it eliminates this bottleneck.
📊 **Impact:** Reduces redundant module resolution during concurrent image batch processing, improving overall execution time.
🔬 **Measurement:** Running the CLI on a batch of images should demonstrate decreased processing time per image, particularly under high concurrency limits.

---
*PR created automatically by Jules for task [13144782063613640986](https://jules.google.com/task/13144782063613640986) started by @nathievzm*