### PR TITLE
🎨 Palette: Add actionable hint to empty state error message

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -48,3 +48,11 @@ them needing to clear the field first.
 
 **Action:** Avoid setting an `initialValue` in CLI text prompts when a descriptive `placeholder` is present, to ensure
 the helpful placeholder text remains visible to the user.
+
+## 2026-05-25 - Actionable Empty State Errors
+
+**Learning:** When users run the tool on a directory that has images in subfolders but not in the root, an error simply
+stating "no valid images found" is confusing and unhelpful.
+
+**Action:** Always provide actionable hints in empty states or error messages, such as suggesting the `--recursive`
+flag, to guide the user toward a solution.

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,8 @@ try {
     const images = getImages(allFiles, input, output)
 
     if (images.length === 0) {
-        throw new ImageError('no valid images found in the input folder 😭')
+        const hint = cli.recursive ? '' : ' (try adding the --recursive flag to check subfolders)'
+        throw new ImageError(`no valid images found in the input folder 😭${hint}`)
     }
 
     note(`found ${color.magenta(images.length)} images to process! 🚀`)


### PR DESCRIPTION
💡 What: The UX enhancement added:
Added an actionable hint to the "no valid images found" error message, suggesting the user try the `--recursive` flag if they are missing files in subdirectories.

🎯 Why: The user problem it solves:
When users run the CLI on a folder that has images inside subfolders (but not at the root level), the standard error ("no valid images found") is confusing and doesn't explain how to fix the problem. By adding an actionable hint, we guide users toward a successful workflow without them needing to read external docs.

♿ Accessibility:
Improved cognitive accessibility by providing clear, actionable error states rather than dead ends.

---
*PR created automatically by Jules for task [15442652058020258037](https://jules.google.com/task/15442652058020258037) started by @nathievzm*