### PR TITLE
🎨 Palette: Add actionable hint to empty state error

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -48,3 +48,12 @@ them needing to clear the field first.
 
 **Action:** Avoid setting an `initialValue` in CLI text prompts when a descriptive `placeholder` is present, to ensure
 the helpful placeholder text remains visible to the user.
+
+## 2026-05-26 - Actionable Hints in Empty States
+
+**Learning:** When a batch process fails to find items (like no images found in a directory), a simple "not found" error
+leaves the user stuck, especially if the expected files are nested and the CLI requires a specific flag (like
+`--recursive`) to search subdirectories.
+
+**Action:** Always provide actionable hints in error messages or empty states (e.g., suggesting the `--recursive` flag)
+to guide the user toward a solution.

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,10 @@ try {
     const images = getImages(allFiles, input, output)
 
     if (images.length === 0) {
-        throw new ImageError('no valid images found in the input folder 😭')
+        const hint = cli.recursive
+            ? ''
+            : '\n💡 hint: if your images are in subfolders, try adding the --recursive (-r) flag!'
+        throw new ImageError(`no valid images found in the input folder 😭${hint}`)
     }
 
     note(`found ${color.magenta(images.length)} images to process! 🚀`)


### PR DESCRIPTION
💡 What: Added a conditional hint to the `ImageError` thrown when no valid images are found in the target directory. It suggests using the `--recursive` flag if the user hasn't already provided it.
🎯 Why: A generic "no images found" error leaves users stuck if their images are nested in subfolders. An actionable hint guides them to the solution immediately.
📸 Before/After: Visual text change.
♿ Accessibility: Improves overall usability and clarity of error states.

---
*PR created automatically by Jules for task [3423752475667986593](https://jules.google.com/task/3423752475667986593) started by @nathievzm*