### PR TITLE
🎨 Palette: add actionable hint for recursive search when no images found

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -48,3 +48,11 @@ them needing to clear the field first.
 
 **Action:** Avoid setting an `initialValue` in CLI text prompts when a descriptive `placeholder` is present, to ensure
 the helpful placeholder text remains visible to the user.
+
+## 2025-02-23 - Actionable Hints in Empty States
+
+**Learning:** When a batch process fails because it cannot find items (like images in a folder), simply stating 'none
+found' leaves users stuck. They often forget or don't know about flags to search subdirectories.
+
+**Action:** Always provide actionable hints in empty states or error messages (e.g., suggesting the `--recursive` flag)
+to guide the user toward a solution.

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,11 @@ try {
     const images = getImages(allFiles, input, output)
 
     if (images.length === 0) {
-        throw new ImageError('no valid images found in the input folder 😭')
+        const hint =
+            !cli.recursive && allFiles.length > 0
+                ? '\n💡 hint: try adding the --recursive (-r) flag if your images are in subfolders'
+                : ''
+        throw new ImageError(`no valid images found in the input folder 😭${hint}`)
     }
 
     note(`found ${color.magenta(images.length)} images to process! 🚀`)


### PR DESCRIPTION
💡 **What**: Added an actionable hint when the CLI fails to find images in the input directory.
🎯 **Why**: When a batch process fails because it cannot find items, simply stating 'none found' leaves users stuck. Users often forget or don't know about flags to search subdirectories. Providing an actionable hint (like suggesting the `--recursive` flag) guides the user toward a solution.
📸 **Before/After**: The error message now displays `💡 hint: try adding the --recursive (-r) flag if your images are in subfolders` when appropriate.
♿ **Accessibility**: Improves cognitive accessibility and overall usability by providing clear recovery instructions instead of just an error.

---
*PR created automatically by Jules for task [15623487805300495471](https://jules.google.com/task/15623487805300495471) started by @nathievzm*