### PR TITLE
🎨 Palette: Add actionable hint to empty state error

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -48,3 +48,12 @@ them needing to clear the field first.
 
 **Action:** Avoid setting an `initialValue` in CLI text prompts when a descriptive `placeholder` is present, to ensure
 the helpful placeholder text remains visible to the user.
+
+## 2026-05-28 - Actionable Empty State Hints
+
+**Learning:** When batch processing fails to find items (empty state), users often don't know why. Providing an
+actionable hint based on the current CLI flags (like suggesting `--recursive`) turns a dead-end error into a helpful
+guide.
+
+**Action:** Always check the current context (e.g., flags used) and provide contextual hints in empty state error
+messages.

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,8 @@ try {
     const images = getImages(allFiles, input, output)
 
     if (images.length === 0) {
-        throw new ImageError('no valid images found in the input folder 😭')
+        const hint = cli.recursive ? '' : ' (hint: try adding the --recursive flag if they are in subfolders 💡)'
+        throw new ImageError(`no valid images found in the input folder 😭${hint}`)
     }
 
     note(`found ${color.magenta(images.length)} images to process! 🚀`)


### PR DESCRIPTION
* 💡 What: Added an actionable hint to the "no valid images" error message suggesting the user try the `--recursive` flag if it wasn't provided.
* 🎯 Why: When batch processing fails to find items, users often don't know why. Providing an actionable hint based on the current CLI flags turns a dead-end error into a helpful guide.
* 📸 Before/After: N/A (CLI change)
* ♿ Accessibility: Improves CLI usability by providing clear, context-aware recovery steps.

---
*PR created automatically by Jules for task [2715988413975633997](https://jules.google.com/task/2715988413975633997) started by @nathievzm*