### PR TITLE
🎨 Palette: add actionable recursive hint to empty state

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -48,3 +48,12 @@ them needing to clear the field first.
 
 **Action:** Avoid setting an `initialValue` in CLI text prompts when a descriptive `placeholder` is present, to ensure
 the helpful placeholder text remains visible to the user.
+
+## 2026-05-29 - Actionable CLI Empty State Hints
+
+**Learning:** When a batch process fails to find items (like nested images), users might not realize they need a
+specific flag (like `--recursive`). A generic "no images found" error is less helpful than one that suggests a possible
+solution.
+
+**Action:** Always provide actionable hints in error messages or empty states (e.g., suggesting the `--recursive` flag)
+to guide the user toward a solution.

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ try {
     const images = getImages(allFiles, input, output)
 
     if (images.length === 0) {
-        throw new ImageError('no valid images found in the input folder 😭')
+        throw new ImageError('no valid images found in the input folder 😭 (try adding the --recursive flag?)')
     }
 
     note(`found ${color.magenta(images.length)} images to process! 🚀`)


### PR DESCRIPTION
💡 **What:** Added an actionable hint ("try adding the `--recursive` flag?") to the CLI error message thrown when no valid images are found in the input directory.

🎯 **Why:** When users run the tool against a directory containing only nested images without specifying the recursive flag, they receive a generic "no valid images found" error. This micro-UX enhancement acts as an empty state call-to-action, directly guiding users toward the likely solution rather than leaving them to guess why their files weren't detected.

📸 **Before/After:**
*Before:* `image issue: no valid images found in the input folder 😭`
*After:* `image issue: no valid images found in the input folder 😭 (try adding the --recursive flag?)`

---
*PR created automatically by Jules for task [14293500155985788864](https://jules.google.com/task/14293500155985788864) started by @nathievzm*