### PR TITLE
🎨 Palette: Surface underlying error causes in CLI for better debugging

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -56,3 +56,12 @@ stating "no valid images found" is confusing and unhelpful.
 
 **Action:** Always provide actionable hints in empty states or error messages, such as suggesting the `--recursive`
 flag, to guide the user toward a solution.
+
+## 2026-05-30 - Surfacing Underlying CLI Errors
+
+**Learning:** When a CLI operation fails due to a complex underlying tool (like image conversion via sharp), displaying
+only the top-level error (e.g. "error processing file") hides crucial debugging context, leaving users stuck without
+knowing if it's an unsupported format, a missing dependency, or a bad parameter.
+
+**Action:** Always surface the underlying `cause` message when handling and displaying custom CLI error classes,
+ensuring the user gets the full context needed to resolve the issue.

--- a/src/lib/error.ts
+++ b/src/lib/error.ts
@@ -22,9 +22,28 @@ export class LumiError extends Error {
      *
      * @returns The error message, or a generic string if the type is unknown.
      */
+    // eslint-disable-next-line max-statements
     static getMessage(error: unknown) {
         if (error instanceof Error) {
-            return error.message
+            let { message } = error
+            const { cause } = error
+
+            if (cause instanceof Error && cause.message) {
+                message += `: ${cause.message}`
+            } else if (typeof cause === 'string' && cause) {
+                message += `: ${cause}`
+            } else if (typeof cause === 'object' && cause !== null) {
+                // eslint-disable-next-line no-unsafe-type-assertion
+                const causeObj = cause as Record<string, unknown>
+
+                if (typeof causeObj['message'] === 'string' && causeObj['message']) {
+                    message += `: ${causeObj['message']}`
+                } else if (causeObj['cause'] instanceof Error && causeObj['cause'].message) {
+                    message += `: ${causeObj['cause'].message}`
+                }
+            }
+
+            return message
         }
 
         if (typeof error === 'string') {


### PR DESCRIPTION
💡 **What:** Added logic to `LumiError.getMessage` to retrieve and append the `error.cause` message if it exists.
🎯 **Why:** Hiding underlying tool errors (such as sharp failing due to bad image format or disk space issues) leads to a poor CLI developer experience. Surfacing the `cause` makes errors actually actionable for users.
♿ **Accessibility/UX:** Improves the UX for troubleshooting and debugging failed jobs.

Added a reflection learning in `.jules/palette.md` noting the importance of underlying error visibility. Tests, formatting, and linting all pass.

---
*PR created automatically by Jules for task [260706596812411712](https://jules.google.com/task/260706596812411712) started by @nathievzm*