### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal via Null Bytes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -68,3 +68,10 @@ terminate strings and bypass directory boundary checks.
 
 **Prevention:** Explicitly reject null bytes ('\0') in all user-provided path components before passing them to
 `node:path` functions or combining them.
+
+## 2024-05-28 - Path Traversal bypass via null bytes and path.join
+**Vulnerability:** Path traversal vulnerability due to null bytes (`\0`) effectively erasing following traversal tokens (`..`) during `node:path` normalization operations like `join` or `resolve`. This allowed traversing paths while bypassing checks later performed by `guard` using `startsWith` or explicit `\0` string detection on the joined string.
+
+**Learning:** `path.join` and `path.resolve` can mutate user input containing null bytes, either truncating it or consuming them when resolving `..`. If a guard expects to test the final path, it might see a perfectly valid-looking normalized path instead of the malicious one containing `\0`, while Node's C++ filesystem functions would still respect the null terminator to drop the suffix, or `join` removed the `\0` but kept the `..` resulting in traversal depending on ordering. Actually, the main issue is that `join` ignores/erases `\0` along with `..` or leaves the string altered such that the malicious traversal tokens bypass prefix checking.
+
+**Prevention:** Always validate individual user input components for null bytes (`\0`) *before* concatenating them using any `node:path` normalization functions, rather than checking the final aggregated path.

--- a/src/lib/image.ts
+++ b/src/lib/image.ts
@@ -4,7 +4,7 @@ import { type Option } from '@clack/prompts'
 import imageExtensions from 'image-extensions'
 import { type AvailableFormatInfo, type default as sharpType } from 'sharp'
 
-import { ImageError } from './error'
+import { FolderError, ImageError } from './error'
 import { guard } from './folder'
 import { askExtensions, askWidthAndHeight } from './prompt'
 
@@ -107,6 +107,10 @@ const getSharpFormats = async () => {
  * @returns `true` if the file is a processable image, otherwise `false`.
  */
 const isProcessable = (file: string, input: string, output: string) => {
+    if (file.includes('\0')) {
+        throw new FolderError('path traversal detected 🚨')
+    }
+
     const ext = extname(file)
     const isImage = validExtensions.has(ext.toLowerCase())
     const isInOutput = join(input, file).startsWith(output)
@@ -211,8 +215,13 @@ export const getExtensions = async (images: readonly string[], format?: string) 
  * @throws { ImageError } If the image processing fails or if a path traversal attempt is detected during output
  *   resolution.
  */
+// eslint-disable-next-line max-statements
 export const resize = async (params: ResizeParams) => {
     const { image, input, output, width, height, name, extension } = params
+
+    if (image.includes('\0') || name.includes('\0') || extension.includes('\0')) {
+        throw new FolderError('path traversal detected 🚨')
+    }
 
     try {
         const inputPath = join(input, image)


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A path traversal vulnerability existed where an attacker could provide an image path containing null bytes (`\0`) and traversal tokens (`..`). Node.js's `path.join()` normalizes the sequence and can erase the null byte alongside `..`, thereby bypassing the subsequent check in `guard()` which scans the final unified path for `\0`. This could allow an attacker to bypass directory boundary validations and read or write files outside the intended input/output folders.
🎯 Impact: Exploitation could lead to unauthorized file reads or writes on the system executing the `lumi` CLI.
🔧 Fix: Validated the individual path variables (`file` in `isProcessable`, and `image`, `name`, `extension` in `resize`) for null bytes before passing them to any `node:path` functions. Throws a `FolderError` defensively.
✅ Verification: Ensure the linters `bun run lint` and `bun run fmt:check` pass. Tests should confirm no regressions.

---
*PR created automatically by Jules for task [3308496331003176319](https://jules.google.com/task/3308496331003176319) started by @nathievzm*