### PR TITLE
🎨 Palette: Surface underlying error causes for better UX

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -56,3 +56,11 @@ stating "no valid images found" is confusing and unhelpful.
 
 **Action:** Always provide actionable hints in empty states or error messages, such as suggesting the `--recursive`
 flag, to guide the user toward a solution.
+
+## 2026-05-31 - Surface Underlying Error Causes
+
+**Learning:** Hiding the underlying cause of an error behind a generic top-level message prevents users from
+understanding the full debugging context needed to resolve issues in CLI applications.
+
+**Action:** Always surface the underlying `cause` message (e.g., `error.cause.message`) when handling and displaying
+custom CLI error classes to provide users with the necessary context.

--- a/src/lib/error.ts
+++ b/src/lib/error.ts
@@ -24,6 +24,14 @@ export class LumiError extends Error {
      */
     static getMessage(error: unknown) {
         if (error instanceof Error) {
+            if (error.cause instanceof Error) {
+                return `${error.message} - ${error.cause.message}`
+            }
+
+            if (typeof error.cause === 'string') {
+                return `${error.message} - ${error.cause}`
+            }
+
             return error.message
         }
 


### PR DESCRIPTION
🎨 Palette: Surface underlying error causes for better UX

💡 What: Updated `LumiError.getMessage` to dynamically extract and append `error.cause.message` (or the stringified cause) when presenting errors. Added an entry to `.jules/palette.md`.
🎯 Why: Generic top-level error messages (like "could not read the input folder") hide the underlying reason (like "permission denied" or "no such file or directory"). Surfacing the cause provides users with the full debugging context they need to take actionable steps.
📸 Before/After: Not applicable (CLI output change).
♿ Accessibility: Improves cognitive accessibility by providing clearer, more actionable error feedback to the user.

---
*PR created automatically by Jules for task [12086281830169548774](https://jules.google.com/task/12086281830169548774) started by @nathievzm*