### PR TITLE
🎨 Palette: Improve error message clarity by surfacing cause

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -56,3 +56,8 @@ stating "no valid images found" is confusing and unhelpful.
 
 **Action:** Always provide actionable hints in empty states or error messages, such as suggesting the `--recursive`
 flag, to guide the user toward a solution.
+## 2025-06-01 - Improve Error Messages by Surfacing the Cause
+
+**Learning:** When creating custom error classes that wrap built-in or dependency-thrown errors (like `EACCES` from Node.js, or file read errors), the top-level error message often obscures the actual root cause (e.g. "image issue" vs "permission denied"). By actively inspecting `error.cause.message` within error handlers and displaying it alongside the generic message, we provide significantly richer debugging context for users troubleshooting failures.
+
+**Action:** Always surface the underlying `cause` message (e.g., `error.cause.message`) when handling custom CLI error classes to provide users with full context, rather than hiding it behind generic messages.

--- a/src/lib/error.ts
+++ b/src/lib/error.ts
@@ -24,6 +24,9 @@ export class LumiError extends Error {
      */
     static getMessage(error: unknown) {
         if (error instanceof Error) {
+            if (error.cause instanceof Error) {
+                return `${error.message}: ${error.cause.message}`
+            }
             return error.message
         }
 


### PR DESCRIPTION
💡 **What:** Modified `LumiError.getMessage` to surface the `error.cause.message` if it exists.
🎯 **Why:** Instead of hiding the underlying issue (e.g., "Permission denied", "No such file or directory") behind a generic top-level error like "folder issue: could not read the input folder", we now show the user exactly what went wrong. This provides significantly better debugging context and makes troubleshooting the CLI much more intuitive.
♿ **Accessibility:** This improves the "developer accessibility" of the CLI by making error messages actionable and clear, preventing users from having to guess why a file operation failed.

---
*PR created automatically by Jules for task [2241702912902247737](https://jules.google.com/task/2241702912902247737) started by @nathievzm*